### PR TITLE
change save strategy for menus and improve opening hours

### DIFF
--- a/mensa-api/src/main/java/com/example/mensa/retrieval/FoodProviderParser.java
+++ b/mensa-api/src/main/java/com/example/mensa/retrieval/FoodProviderParser.java
@@ -12,6 +12,7 @@ import org.jsoup.select.Elements;
 
 import java.time.DayOfWeek;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -180,11 +181,17 @@ public class FoodProviderParser implements Parser<FetchedFoodProvider> {
             Elements tableRowItems = tableRow.children();
 
             // Do we have opening hours?
-            if (tableRowItems.size() > 2) {
-                String[] hours = tableRowItems.get(1).text().split(" - | ");
+            if (tableRowItems.size() > 2 || (isCafeteria && tableRowItems.size() == 2)) {
+                String[] hours = Arrays.stream(tableRowItems.get(1).text().split(" - | ")).map(o -> o.replace("-", "")).toArray(String[]::new);
                 String mealOutTill = "";
-                if (!tableRowItems.get(2).text().isEmpty()) {
-                    mealOutTill = tableRowItems.get(2).text().split(" ")[2];
+                if (tableRowItems.size() == 3 && !tableRowItems.get(2).text().isEmpty()) {
+                    if (isCafeteria) {
+                        fetchedOpeningHoursList.addAll(constructOpeningHours(
+                                new Elements(new Element("dummyTableRows").appendChildren(
+                                        List.of(tableRowItems.get(0), tableRowItems.get(2), new Element("td"))
+                                )), isCafeteria));
+                    } else
+                        mealOutTill = tableRowItems.get(2).text().split(" ")[2];
                 }
                 int numberOfLoopExecutions = weekdaysToIteratorNumber(tableRowItems.get(0).text());
 


### PR DESCRIPTION
_### **Database:**_
**Menus and Meals:**
- menus don't have a "meals" document anymore, instead all meals are saved directly under "menus"
- meals have extra fields: "date" and "foodProviderId"
- meal-documents now have a random Id, as their name is not unique anymore
- should allow querying all meals from a specific day and after, like (one has to map meals to dates later): database.groupCollection("meals").whereGreaterOrEqual("date", now).whereEqualTo("foodProviderId", id)

**Opening Hours:**
- added support for multiple opening hours on the same day
- for sake of minimal requests - opening hours for one day are saved in a single 1d array (just lined up)
- as we know the number of fields of one opening hour (4), we can infer the number of opening hours (array_size = 8 => 2 opening hours for that day)

_### **Parser:**_
- fixed a bug that prevented parsing of opening hours for cafeterias
- Enhanced constructOpeningHours method to also parse multiple opening hours for the same day